### PR TITLE
Secondary node support

### DIFF
--- a/teamcity-crowd-plugin-server/src/main/kotlin/teamcity/crowd/plugin/IOGuardWrapper.kt
+++ b/teamcity-crowd-plugin-server/src/main/kotlin/teamcity/crowd/plugin/IOGuardWrapper.kt
@@ -1,0 +1,55 @@
+package teamcity.crowd.plugin
+
+import com.intellij.openapi.diagnostic.Logger
+import jetbrains.buildServer.util.FuncThrow
+
+/**
+ * TeamCity secondary nodes run under the security manager which prohibits network calls, file modifications and start of the processes by default.
+ * This is done to prevent modification of a state in external services or to prevent simultaneous file modification access
+ * to files under the shared data directory (all TeamCity nodes share the same data directory).
+ *
+ * <br>
+ * If network operation is safe (for instance, the operation only reads data, and does not change the state),
+ * then to allow it on secondary nodes it should be wrapped into the IOGuard call.
+ *
+ * <br>
+ * The class here works as a wrapper on top of the IOGuard. Since older TeamCity versions did not have the IOGuard class
+ * in order to continue support them we have to use Java reflection.
+ *
+ * <br>
+ * See also: https://plugins.jetbrains.com/docs/teamcity/plugin-development-faq.html#How+to+adapt+plugin+for+secondary+node
+ * and https://www.jetbrains.com/help/teamcity/multinode-setup.html
+ *
+ */
+object IOGuardWrapper {
+    private val ioGuardClass: Class<*>?
+    private val logger: Logger = Logger.getInstance(IOGuardWrapper::class.qualifiedName)
+
+    init {
+        ioGuardClass = getIOGuardClass()
+    }
+
+    private fun getIOGuardClass(): Class<*>? {
+        return try {
+            Class.forName("jetbrains.buildServer.serverSide.IOGuard")
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun <R, E : Throwable?> allowNetworkCall(func: FuncThrow<R, E>): R {
+        if (ioGuardClass == null) {
+            // this server does not have the IOGuard class yet
+            return func.apply()
+        }
+
+        try {
+            val method = ioGuardClass.getMethod("allowNetworkCall", FuncThrow::class.java)
+            return method.invoke(func) as R
+        } catch (e: Exception) {
+            // for some reason there is no allowNetworkCall in this class
+            logger.debug("Could not find a method with name allowNetworkCall in the class: " + ioGuardClass.name)
+            return func.apply()
+        }
+    }
+}

--- a/teamcity-crowd-plugin-server/src/main/kotlin/teamcity/crowd/plugin/PluginCrowdClient.kt
+++ b/teamcity-crowd-plugin-server/src/main/kotlin/teamcity/crowd/plugin/PluginCrowdClient.kt
@@ -10,6 +10,7 @@ import com.atlassian.crowd.exception.ApplicationPermissionException
 import com.atlassian.crowd.exception.InvalidAuthenticationException
 import com.atlassian.crowd.service.client.ClientProperties
 import com.atlassian.crowd.service.factory.CrowdClientFactory
+import jetbrains.buildServer.util.FuncThrow
 
 interface PluginCrowdClient {
     fun loginUserWithPassword(username: String, password: String): User?
@@ -37,7 +38,7 @@ class TeamCityPluginCrowdClient(private val crowdClient: CrowdClient, loggerFact
 
     override fun loginUserWithPassword(username: String, password: String): User? {
         try {
-            return crowdClient.authenticateUser(username, password)
+            return IOGuardWrapper.allowNetworkCall<User?, Exception>( FuncThrow { crowdClient.authenticateUser(username, password) } )
         } catch (e: UserNotFoundException) {
             logger.warn("User with name [$username] doesn't exists.", e)
         } catch (e: InactiveAccountException) {
@@ -58,7 +59,7 @@ class TeamCityPluginCrowdClient(private val crowdClient: CrowdClient, loggerFact
 
     override fun getUserGroups(username: String): Collection<Group> {
         try {
-            return crowdClient.getGroupsForUser(username, 0, Integer.MAX_VALUE)
+            return IOGuardWrapper.allowNetworkCall<Collection<Group>, Exception>( FuncThrow { crowdClient.getGroupsForUser(username, 0, Integer.MAX_VALUE) } )
         } catch (e: UserNotFoundException) {
             logger.warn("User with name [$username] doesn't exists.", e)
         } catch (e: OperationFailedException) {
@@ -72,5 +73,4 @@ class TeamCityPluginCrowdClient(private val crowdClient: CrowdClient, loggerFact
         }
         return emptyList()
     }
-
 }

--- a/teamcity-crowd-plugin-server/src/main/kotlin/teamcity/crowd/plugin/config/CrowdPluginConfiguration.kt
+++ b/teamcity-crowd-plugin-server/src/main/kotlin/teamcity/crowd/plugin/config/CrowdPluginConfiguration.kt
@@ -37,7 +37,7 @@ class CrowdPluginConfiguration(configDirectory: String, configFileName: String, 
         }
 
         val pluginProperties = Properties()
-        val reader = IOGuardWrapper.allowNetworkCall<FileReader,Exception>( FuncThrow { FileReader(configurationFile) } )
+        val reader = FileReader(configurationFile)
         pluginProperties.load(reader)
 
         clientProperties.updateProperties(pluginProperties)

--- a/teamcity-crowd-plugin-server/src/main/kotlin/teamcity/crowd/plugin/config/CrowdPluginConfiguration.kt
+++ b/teamcity-crowd-plugin-server/src/main/kotlin/teamcity/crowd/plugin/config/CrowdPluginConfiguration.kt
@@ -1,7 +1,9 @@
 package teamcity.crowd.plugin.config
 
 import com.atlassian.crowd.service.client.ClientProperties
+import jetbrains.buildServer.util.FuncThrow
 import jetbrains.buildServer.web.openapi.PluginException
+import teamcity.crowd.plugin.IOGuardWrapper
 import teamcity.crowd.plugin.utils.LoggerFactory
 import java.io.File
 import java.io.FileReader
@@ -35,7 +37,7 @@ class CrowdPluginConfiguration(configDirectory: String, configFileName: String, 
         }
 
         val pluginProperties = Properties()
-        val reader = FileReader(configurationFile)
+        val reader = IOGuardWrapper.allowNetworkCall<FileReader,Exception>( FuncThrow { FileReader(configurationFile) } )
         pluginProperties.load(reader)
 
         clientProperties.updateProperties(pluginProperties)

--- a/teamcity-plugin.xml
+++ b/teamcity-plugin.xml
@@ -13,6 +13,6 @@
             <email>@VendorEmail@</email>
         </vendor>
     </info>
-    <deployment use-separate-classloader="false"/>
+    <deployment use-separate-classloader="true" node-responsibilities-aware="true"/>
 </teamcity-plugin>
 


### PR DESCRIPTION
This change makes it possible to use the plugin on TeamCity secondary nodes (before the change the secondary node would not load the plugin as it is not marked as "secondary node ready").

Note I also changed use-separate-classloader attribute from false to true. This should be safe, and there is a significant benefit: now the plugin can be loaded or unloaded in runtime without the server restart.